### PR TITLE
Fix duplicate key exception in GetRemoteObject

### DIFF
--- a/src/ScubaDiver/MsvcDiver.cs
+++ b/src/ScubaDiver/MsvcDiver.cs
@@ -744,6 +744,20 @@ namespace ScubaDiver
 
             try
             {
+                // Check if the object is already frozen
+                if (_freezer.IsFrozen(objAddr))
+                {
+                    Logger.Debug($"[MsvcDiver][MakeObjectResponse] Object at 0x{objAddr:X16} is already frozen.");
+                    ObjectDump od = new ObjectDump()
+                    {
+                        Type = typeName,
+                        RetrivalAddress = objAddr,
+                        PinnedAddress = objAddr,
+                        HashCode = 0x0bad0bad
+                    };
+                    return JsonConvert.SerializeObject(od);
+                }
+
                 // TODO: Wrong for x86
                 long vftable = Marshal.ReadInt64(new IntPtr((long)objAddr));
                 Rtti.TypeInfo typeInfo = ResolveTypeFromVftableAddress((nuint)vftable);

--- a/src/ScubaDiver/MsvcDiver.cs
+++ b/src/ScubaDiver/MsvcDiver.cs
@@ -748,14 +748,14 @@ namespace ScubaDiver
                 if (_freezer.IsFrozen(objAddr))
                 {
                     Logger.Debug($"[MsvcDiver][MakeObjectResponse] Object at 0x{objAddr:X16} is already frozen.");
-                    ObjectDump od = new ObjectDump()
+                    ObjectDump alreadyFrozenObjDump = new ObjectDump()
                     {
                         Type = typeName,
                         RetrivalAddress = objAddr,
                         PinnedAddress = objAddr,
                         HashCode = 0x0bad0bad
                     };
-                    return JsonConvert.SerializeObject(od);
+                    return JsonConvert.SerializeObject(alreadyFrozenObjDump);
                 }
 
                 // TODO: Wrong for x86

--- a/src/ScubaDiver/MsvcFrozenItemsCollection.cs
+++ b/src/ScubaDiver/MsvcFrozenItemsCollection.cs
@@ -32,6 +32,13 @@ namespace ScubaDiver
             }
         }
 
+        public bool IsFrozen(ulong objAddress)
+        {
+            lock (_lock)
+            {
+                return _frozenItemsToDestructors.ContainsKey(objAddress);
+            }
+        }
 
         /// <summary>
         /// Unpins an object


### PR DESCRIPTION
Fixes #17

Fix the issue of duplicate key exception when using `GetRemoteObject` multiple times on the same Candidate/address.

* **Add `IsFrozen` method in `MsvcFrozenItemsCollection` class**
  - Add a method `IsFrozen` to check if an object is already frozen.
  - Implement the `IsFrozen` method to return true if the object is in `_frozenItemsToDestructors`.

* **Modify `MakeObjectResponse` method in `MsvcDiver` class**
  - Check if an object is already frozen before attempting to freeze it.
  - Use the `IsFrozen` method from `MsvcFrozenItemsCollection` to check if an object is already frozen.
  - Return the already frozen object if it is found to be frozen.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theXappy/RemoteNET/issues/17?shareId=4d725ade-bc3b-47e9-9a54-82782bc93f51).